### PR TITLE
Clarify how to view snake AI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ required to display the board during the demo:
 pip install torch numpy matplotlib
 python games/snake/snake_ai.py
 ```
+
+Training may take a few minutes on a CPU. Once it completes, a window will
+open showing the agent playing several games automatically. If no window
+appears, ensure that `matplotlib` is installed and that your environment is
+able to display GUI windows.

--- a/games/snake/README.md
+++ b/games/snake/README.md
@@ -28,3 +28,5 @@ required for visualizing the board:
 pip install torch numpy matplotlib
 python snake_ai.py
 ```
+
+Training might take a short while. After it finishes, the script opens a matplotlib window showing the trained snake play several games. If you do not see any window, check your `matplotlib` installation and GUI support.


### PR DESCRIPTION
## Summary
- clarify that `snake_ai.py` opens a window with a demo after training
- explain that matplotlib needs GUI capability

## Testing
- `python -m py_compile games/snake/snake_ai.py`
- `python -m py_compile games/snake/main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f78d3b950832aa609beb6dd89bad7